### PR TITLE
Ajoute un message si aucun destinataire n'est renseigné

### DIFF
--- a/admin/notifications.php
+++ b/admin/notifications.php
@@ -112,7 +112,11 @@ if( !class_exists( 'VOYNOTIF_admin_notifications' ) ) {
                 } elseif($notification->recipient_type == 'users' ) {    
                     $users_to_display = array();
                     $users = $notification->get_field('recipient_users');
-                    foreach( $users as $user_id ) {
+                    if(empty($users)) {
+                        echo __('No recipient', 'notifications-center');
+                        return;
+                    }
+                    foreach($users as $user_id) {
                         $user_data = get_userdata($user_id);
                         $users_to_display[] = $user_data->user_login;
                     }

--- a/languages/notifications-center-fr_FR.po
+++ b/languages/notifications-center-fr_FR.po
@@ -218,6 +218,11 @@ msgstr "Inactif"
 msgid "All %s users"
 msgstr ""
 
+#: admin/notifications.php:116
+#, php-format
+msgid "No recipient"
+msgstr "Aucun destinataire"
+
 #: admin/notifications.php:130
 msgid "All types"
 msgstr "Tous les types"


### PR DESCRIPTION
Retire l'avertissement suivant, qui était présent dans la liste des notifications quand une notification était créée sans destinataire :

`Warning: foreach() argument must be of type array|object, string given in /var/www/vhosts/voyelle-dev.fr/dev-notifications-center/voy_content/plugins/notifications-center/admin/notifications.php on line 115`