### PR TITLE
Feature/override notifs par defaut

### DIFF
--- a/core/compat/duplicate-post.php
+++ b/core/compat/duplicate-post.php
@@ -15,7 +15,7 @@ class VOYNOTIF_compat_duplicate_post extends VOYNOTIF_compat {
     }
     
     function init() {
-        include_once( VOYNOTIF_DIR .  '/notifications/content_duplicate.php');
+        VOYNOTIF_plugin::include_notification_template( 'content_duplicate.php' );
     }
     
 }

--- a/core/compat/woocommerce.php
+++ b/core/compat/woocommerce.php
@@ -26,7 +26,7 @@ class VOYNOTIF_compat_woocommerce extends VOYNOTIF_compat {
         
         add_filter( 'voynotif/logs/context/type=wc_new_order', array( $this, 'log_context' ), 10, 2 );
         
-        include_once( VOYNOTIF_DIR .  '/notifications/woocommerce/new-order.php');
+        VOYNOTIF_plugin::include_notification_template( 'woocommerce/new-order.php' );
     }
     
     public function add_settings( $fields ) {

--- a/notifications_center.php
+++ b/notifications_center.php
@@ -219,23 +219,29 @@ if( !class_exists( 'VOYNOTIF_plugin' ) ) {
             include_once('core/compat/woocommerce.php'); 
             
             //Load Notifications
-            include_once('notifications/comment_new.php');
-            include_once('notifications/comment_reply.php');
-            include_once('notifications/comment_moderate.php');
-            include_once('notifications/content_draft.php');
-            include_once('notifications/content_future.php');
-            include_once('notifications/content_pending.php');
-            include_once('notifications/content_publish.php');
-            include_once('notifications/content_trash.php');
-            include_once('notifications/core_update.php');            
-            include_once('notifications/user_login.php');
-            include_once('notifications/user_password_changed.php');
-            include_once('notifications/user_password_reset.php');
-            include_once('notifications/user_register.php');
-            
-            //Check for udpate
-            if( $this->updater->current_version !== $this->updater->new_version ) {
-                $this->updater->update();
+            $notifications = [
+                'comment_reply.php',
+                'comment_moderate.php',
+                'comment_new.php',
+                'content_draft.php',
+                'content_future.php',
+                'content_pending.php',
+                'content_publish.php',
+                'content_trash.php',
+                'core_update.php',
+                'user_login.php',
+                'user_password_changed.php',
+                'user_password_reset.php',
+                'user_register.php'
+            ];
+            foreach ($notifications as $notification) {
+                // Check if a template override exists in the theme
+                $path = get_theme_file_path('/templates/parts/notifications-center/' . $notification);
+                if (file_exists($path)) {
+                    include_once($path);
+                    continue;
+                }
+                include_once('notifications/' . $notification);
             }
             
             /**

--- a/notifications_center.php
+++ b/notifications_center.php
@@ -235,13 +235,7 @@ if( !class_exists( 'VOYNOTIF_plugin' ) ) {
                 'user_register.php'
             ];
             foreach ($notifications as $notification) {
-                // Check if a template override exists in the theme
-                $path = get_theme_file_path('/templates/parts/notifications-center/' . $notification);
-                if (file_exists($path)) {
-                    include_once($path);
-                    continue;
-                }
-                include_once('notifications/' . $notification);
+                self::include_notification_template($notification);
             }
             
             /**
@@ -254,6 +248,23 @@ if( !class_exists( 'VOYNOTIF_plugin' ) ) {
              */
             do_action('voynotif/loaded');
 
+        }
+
+        /**
+         * Include a notification template. 
+         * Check if a template override exists in the theme's "templates/parts/notifications-center" folder.
+         *
+         * @author Elouan
+         * @param String $filename the filename of the notification to include (e.g. 'comment_reply.php')
+         * @return void
+         */
+        public static function include_notification_template( $filename ) {
+            // Check if a template override exists in the theme
+            $path = get_theme_file_path('/templates/parts/notifications-center/' . $filename);
+            if (file_exists($path)) {
+                include_once($path);
+            }
+            include_once('notifications/' . $filename);
         }
 
 


### PR DESCRIPTION
Fix Ninadjeret/wp-notifications-center#14

Ajoute la possibilité d'avoir un dossier "theme/{site}/templates/parts/**notifications-center**/" dans lequel mettre des overrides de notifications.
/!\ Un override n'est pas une classe qui extend la notification par défaut, c'est une nouvelle classe qui porte le même nom.

Ceci ne fonctionnera pas :
```
// plugins/notifications-center/notifications/user_login.php
class VOYNOTIF_notification_type_user_login extends VOYNOTIF_notification_type {}

// templates/parts/notifications-center/user_login.php
class VOYNOTIF_ma_notif_override extends VOYNOTIF_notification_type_user_login {}
```

Ceci fonctionnera :
```
// plugins/notifications-center/notifications/user_login.php
class VOYNOTIF_notification_type_user_login extends VOYNOTIF_notification_type {}

// templates/parts/notifications-center/user_login.php
class VOYNOTIF_notification_type_user_login extends VOYNOTIF_notification_type {}
```